### PR TITLE
SASS-1537A - remove fullstop from error message

### DIFF
--- a/conf/messages
+++ b/conf/messages
@@ -945,7 +945,7 @@ expenses.claimEmploymentExpenses.thisIncludes.example3 = uniforms, work clothes 
 expenses.claimEmploymentExpenses.findOutMore = Find out more about
 expenses.claimEmploymentExpenses.findOutMoreLink = claiming employment expenses (opens in new tab)
 expenses.claimEmploymentExpenses.error.noEntry.individual = Select yes if you want to claim employment expenses
-expenses.claimEmploymentExpenses.error.noEntry.agent = Select yes if you want to claim for your client’s employment expenses.
+expenses.claimEmploymentExpenses.error.noEntry.agent = Select yes if you want to claim for your client’s employment expenses
 
 expenses.BusinessTravelOvernightExpenses.title.individual = Do you want to claim business travel and overnight expenses?
 expenses.BusinessTravelOvernightExpenses.title.agent = Do you want to claim your client’s business travel and overnight expenses?

--- a/conf/messages.cy
+++ b/conf/messages.cy
@@ -945,7 +945,7 @@ expenses.claimEmploymentExpenses.thisIncludes.example3 = uniforms, work clothes 
 expenses.claimEmploymentExpenses.findOutMore = Find out more about
 expenses.claimEmploymentExpenses.findOutMoreLink = claiming employment expenses (opens in new tab)
 expenses.claimEmploymentExpenses.error.noEntry.individual = Select yes if you want to claim employment expenses
-expenses.claimEmploymentExpenses.error.noEntry.agent = Select yes if you want to claim for your client’s employment expenses.
+expenses.claimEmploymentExpenses.error.noEntry.agent = Select yes if you want to claim for your client’s employment expenses
 
 expenses.BusinessTravelOvernightExpenses.title.individual = Do you want to claim business travel and overnight expenses?
 expenses.BusinessTravelOvernightExpenses.title.agent = Do you want to claim your client’s business travel and overnight expenses?

--- a/it/controllers/expenses/EmploymentExpensesControllerISpec.scala
+++ b/it/controllers/expenses/EmploymentExpensesControllerISpec.scala
@@ -101,7 +101,7 @@ class EmploymentExpensesControllerISpec extends IntegrationTest with ViewHelpers
     val expectedHeading = "Do you want to claim employment expenses for your client?"
     val expectedCanClaim = "You can claim employment expenses your client did not claim through their employer."
     val expectedErrorTitle = s"Error: $expectedTitle"
-    val expectedErrorText = "Select yes if you want to claim for your client’s employment expenses."
+    val expectedErrorText = "Select yes if you want to claim for your client’s employment expenses"
   }
 
   object ExpectedAgentCY extends SpecificExpectedResults {
@@ -109,7 +109,7 @@ class EmploymentExpensesControllerISpec extends IntegrationTest with ViewHelpers
     val expectedHeading = "Do you want to claim employment expenses for your client?"
     val expectedCanClaim = "You can claim employment expenses your client did not claim through their employer."
     val expectedErrorTitle = s"Error: $expectedTitle"
-    val expectedErrorText = "Select yes if you want to claim for your client’s employment expenses."
+    val expectedErrorText = "Select yes if you want to claim for your client’s employment expenses"
   }
 
   object CommonExpectedEN extends CommonExpectedResults {

--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -5,7 +5,7 @@ object AppDependencies {
 
   val compile = Seq(
     "uk.gov.hmrc"             %% "bootstrap-frontend-play-28" % "5.16.0",
-    "uk.gov.hmrc"             %% "play-frontend-hmrc"         % "1.25.0-play-28",
+    "uk.gov.hmrc"             %% "play-frontend-hmrc"         % "1.26.0-play-28",
     "uk.gov.hmrc"             %% "govuk-template"             % "5.72.0-play-28",
     "uk.gov.hmrc.mongo"       %% "hmrc-mongo-play-28"         % "0.56.0",
     "com.fasterxml.jackson.module" %% "jackson-module-scala"  % "2.12.2"


### PR DESCRIPTION
### Description
Removes a fullstop from the error message picked up in demo
Fullstop is shown in slide error message but should not be there

[Add a link to the relevant story in Jira
[SASS-CHANGE-ME](ADD URL HERE)](https://jira.tools.tax.service.gov.uk/browse/SASS-1537)

### Checklist PR Reviewer
##### Before Reviewing
- [x]  Have you pulled the branch down?
- [x]  Have you assigned yourself to the PR?
- [x]  Have you moved the task to “in review” on JIRA?
- [x]  Have you checked to ensure all dependencies are up to date?
- [x]  Have you checked to ensure its been rebased against the current version of main?

##### Whilst Reviewing
- [x]  Have you run the tests?
- [x]  Have you run the journey tests?
- [x]  Have you looked at the JIRA story to make sure all Acceptance Criteria has been met?

##### After Reviewing
- [x]  Have you checked for merge conflicts or any changes in the current main that may affect the current pull request? i.e. does it need another rebase?
- [x]  Have you checked to make sure there are no builds in the pipeline before you merge?
- [ ]  Have you moved the task to “in pipeline” on Jira?

### Checklist PR Raiser
##### Before creating PR
- [X]  Have you run the tests?
- [X]  Have you run the journey tests? (where applicable)
- [X]  Have you addressed warnings where appropriate?
- [X]  Have you rebased against the current version of main?
- [X]  Have you checked code coverage isn’t lower than previously?

##### After PRs been raised
- [ ]  Have you checked the PR Builder passes?
