### PR TITLE
SASS-1932: Update employment FE to specify user agent for NRS submission

### DIFF
--- a/app/services/NrsService.scala
+++ b/app/services/NrsService.scala
@@ -18,18 +18,23 @@ package services
 
 import connectors.NrsConnector
 import connectors.httpParsers.NrsSubmissionHttpParser.NrsSubmissionResponse
+import play.api.http.HeaderNames
 import play.api.libs.json.Writes
+import play.api.mvc.Request
 import uk.gov.hmrc.http.HeaderCarrier
+import utils.HMRCHeaderNames
 
 import javax.inject.Inject
 import scala.concurrent.Future
 
 class NrsService @Inject() (nrsConnector: NrsConnector) {
 
-  def submit[A](nino: String, payload: A, mtditid: String)(implicit hc: HeaderCarrier, writes: Writes[A]): Future[NrsSubmissionResponse] = {
+  def submit[A](nino: String, payload: A, mtditid: String)(implicit request: Request[_], hc: HeaderCarrier, writes: Writes[A]): Future[NrsSubmissionResponse] = {
 
     val extraHeaders = Seq(
       Some("mtditid" -> mtditid),
+      Some(HeaderNames.USER_AGENT -> "income-tax-employment-frontend"),
+      Some(HMRCHeaderNames.TrueUserAgent -> request.headers.get(HeaderNames.USER_AGENT).getOrElse("No user agent provided")),
       hc.trueClientIp.map(ip => "clientIP" -> ip),
       hc.trueClientPort.map(port => "clientPort" -> port)
     ).flatten

--- a/app/utils/HMRCHeaderNames.scala
+++ b/app/utils/HMRCHeaderNames.scala
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package utils
+
+object HMRCHeaderNames {
+  val TrueUserAgent = "True-User-Agent"
+}

--- a/test/config/MockNrsService.scala
+++ b/test/config/MockNrsService.scala
@@ -20,6 +20,7 @@ import connectors.httpParsers.NrsSubmissionHttpParser.NrsSubmissionResponse
 import org.scalamock.handlers.CallHandler
 import org.scalamock.scalatest.MockFactory
 import play.api.libs.json.Writes
+import play.api.mvc.Request
 import services.NrsService
 import uk.gov.hmrc.http.HeaderCarrier
 
@@ -30,8 +31,8 @@ trait MockNrsService extends MockFactory {
   val mockNrsService: NrsService = mock[NrsService]
 
   def verifySubmitEvent[T](event: T): CallHandler[Future[NrsSubmissionResponse]] = {
-    (mockNrsService.submit(_: String, _: T, _: String)(_: HeaderCarrier, _: Writes[T]))
-      .expects(*, event, *, *, *)
+    (mockNrsService.submit(_: String, _: T, _: String)(_:Request[_], _: HeaderCarrier, _: Writes[T]))
+      .expects(*, event, *, *, *, *)
       .returning(Future.successful(Right()))
   }
 


### PR DESCRIPTION
### Description
Update employment FE to specify `User-Agent` and `True-User-Agent` headers for NRS submission.

[SASS-1932](https://jira.tools.tax.service.gov.uk/browse/SASS-1932)

### Checklist PR Reviewer
##### Before Reviewing
- [x]  Have you pulled the branch down?
- [x]  Have you assigned yourself to the PR?
- [x]  Have you moved the task to “in review” on JIRA?
- [x]  Have you checked to ensure all dependencies are up to date?
- [x]  Have you checked to ensure its been rebased against the current version of main?

##### Whilst Reviewing
- [x]  Have you run the tests?
- [x]  Have you run the journey tests?
- [x]  Have you looked at the JIRA story to make sure all Acceptance Criteria has been met?

##### After Reviewing
- [x]  Have you checked for merge conflicts or any changes in the current main that may affect the current pull request? i.e. does it need another rebase?
- [x]  Have you checked to make sure there are no builds in the pipeline before you merge?
- [ ]  Have you moved the task to “in pipeline” on Jira?

### Checklist PR Raiser
##### Before creating PR
- [X]  Have you run the tests?
- [X]  Have you run the journey tests? (where applicable)
- [X]  Have you addressed warnings where appropriate?
- [X]  Have you rebased against the current version of main?
- [X]  Have you checked code coverage isn’t lower than previously?

##### After PRs been raised
- [X]  Have you checked the PR Builder passes?
