### PR TITLE
SASS-3048: Employment In year no data/pre-pop design iteration

### DIFF
--- a/app/controllers/employment/EmploymentSummaryController.scala
+++ b/app/controllers/employment/EmploymentSummaryController.scala
@@ -54,10 +54,7 @@ class EmploymentSummaryController @Inject()(pageView: EmploymentSummaryView,
       lazy val latestExpenses = if (isInYear) priorData.flatMap(_.latestInYearExpenses) else priorData.flatMap(_.latestEOYExpenses)
       lazy val doExpensesExist = latestExpenses.isDefined
 
-      employmentData match {
-        case Seq() if isInYear && !doExpensesExist => Redirect(appConfig.incomeTaxSubmissionOverviewUrl(taxYear))
-        case _ => Ok(pageView(taxYear, employmentData, doExpensesExist, isInYear, request.user.isAgent))
-      }
+      Ok(pageView(taxYear, employmentData, doExpensesExist, isInYear, request.user.isAgent))
     }
   }
 

--- a/app/views/employment/EmploymentSummaryView.scala.html
+++ b/app/views/employment/EmploymentSummaryView.scala.html
@@ -65,8 +65,10 @@
     }
 
     @{
-        val headingMessage = if (employments.size > 1 || employments.isEmpty) messages("employment.employmentSummary.employers") else messages("common.employer")
-        <h2 id="employer-h2" class="govuk-heading-m govuk-!-margin-top-6">{headingMessage}</h2>
+        if (employments.nonEmpty) {
+            val headingMessage = if (employments.size > 1) messages("employment.employmentSummary.employers") else messages("common.employer")
+            <h2 id="employer-h2" class="govuk-heading-m govuk-!-margin-top-6">{headingMessage}</h2>
+        }
     }
 
     @if(employments.nonEmpty){
@@ -100,14 +102,10 @@
 
     @if(!isInYear) {
         <p class="govuk-body"><a class="govuk-link" href="@EmploymentSummaryController.addNewEmployment(taxYear)">@messages(s"employment.employmentSummary.${if(employments.nonEmpty) "addAnotherEmployer" else "addAnEmployer"}")</a></p>
-    } else {
-        @if(employments.isEmpty){
-            <p class="govuk-body">@messages(s"employment.noEmployers")</p>
-        }
     }
 
-    <h2 id="expenses-h2" class="govuk-heading-m govuk-!-margin-top-9">@messages("employment.expenses.label")</h2>
     @if(expensesExist){
+        <h2 id="expenses-h2" class="govuk-heading-m govuk-!-margin-top-9">@messages("employment.expenses.label")</h2>
         <p id="total-of-expenses" class="govuk-body">@messages(s"employment.expenses.subheading")</p>
     }
 
@@ -127,9 +125,7 @@
             govukSummaryList(SummaryList(Seq(expensesRow)))
         }
     } else {
-        @if(isInYear) {
-            <p class="govuk-body">@messages(s"employment.employmentSummary.cannotAdd.${if(isAgent) "agent" else "individual"}", taxYear.toString)</p>
-        } else {
+        @if(employments.nonEmpty) {
             <p class="govuk-body"><a id="add-expenses" class="govuk-link" href="@EmploymentExpensesController.show(taxYear)">@messages(s"employment.employmentSummary.addExpenses")</a></p>
         }
     }

--- a/it/controllers/employment/EmploymentSummaryControllerISpec.scala
+++ b/it/controllers/employment/EmploymentSummaryControllerISpec.scala
@@ -56,7 +56,7 @@ class EmploymentSummaryControllerISpec extends IntegrationTest with ViewHelpers 
       }
     }
 
-    "redirect when there is employment data returned but no hmrc employment data" which {
+    "render page when there is employment data returned but no hmrc employment data" which {
       lazy val result: WSResponse = {
         authoriseAgentOrIndividual(isAgent = true)
         userDataStub(IncomeTaxUserData(Some(AllEmploymentData(Seq(), None, Seq(anEmploymentSource), None))), nino, taxYear)
@@ -64,11 +64,11 @@ class EmploymentSummaryControllerISpec extends IntegrationTest with ViewHelpers 
       }
 
       "status OK" in {
-        result.status shouldBe SEE_OTHER
+        result.status shouldBe OK
       }
     }
 
-    "redirect the User to the Overview page no data in session" which {
+    "render page when no data in session" which {
       lazy val result: WSResponse = {
         authoriseAgentOrIndividual(isAgent = true)
         userDataStub(IncomeTaxUserData(), nino, taxYear)
@@ -76,8 +76,7 @@ class EmploymentSummaryControllerISpec extends IntegrationTest with ViewHelpers 
       }
 
       "has an SEE_OTHER(303) status" in {
-        result.status shouldBe SEE_OTHER
-        result.header(HeaderNames.LOCATION).contains(overviewUrl(taxYear)) shouldBe true
+        result.status shouldBe OK
       }
 
     }

--- a/test/controllers/employment/EmploymentSummaryControllerSpec.scala
+++ b/test/controllers/employment/EmploymentSummaryControllerSpec.scala
@@ -242,14 +242,13 @@ class EmploymentSummaryControllerSpec extends UnitTest
       }
     }
 
-    "redirect the User to the Overview page no data in session" which {
+    "render summary view when no data in session" which {
       s"has the SEE_OTHER($SEE_OTHER) status" in new TestWithAuth {
         mockGetPriorRight(taxYear, None)
 
         val result: Future[Result] = controller().show(taxYear)(fakeRequest.withSession(SessionValues.TAX_YEAR -> taxYear.toString))
 
-        status(result) shouldBe SEE_OTHER
-        redirectUrl(result) shouldBe mockAppConfig.incomeTaxSubmissionOverviewUrl(taxYear)
+        status(result) shouldBe OK
       }
     }
   }

--- a/test/views/employment/EmploymentSummaryViewSpec.scala
+++ b/test/views/employment/EmploymentSummaryViewSpec.scala
@@ -71,7 +71,7 @@ class EmploymentSummaryViewSpec extends ViewUnitTest {
 
     val addExpensesSelector = s"#add-expenses"
 
-    def addEmployerSelector(n: Int = 3): String = s"#main-content > div > div > p:nth-child($n) > a"
+    def addEmployerSelector = "#main-content > div > div > p.govuk-body > a"
 
     val addSelector = "#main-content > div > div > dl:nth-child(7) > div > dd > a"
     val cannotAddSelector = "#main-content > div > div > p:nth-child(7)"
@@ -267,7 +267,6 @@ class EmploymentSummaryViewSpec extends ViewUnitTest {
           linkCheck(s"$change$change $employerName2", changeEmployerSelector(2), EmployerInformationController.show(taxYearEOY, employmentId2).url)
           linkCheck(s"$remove $remove $employerName2", removeEmployerSelector(2), RemoveEmploymentController.show(taxYearEOY, employmentId2).url)
           linkCheck(addAnother, addAnotherSelector, EmploymentSummaryController.addNewEmployment(taxYearEOY).url, isExactUrlMatch = false)
-          textOnPageCheck(expenses, expensesHeadingSelector, "as a heading")
           linkCheck(addExpenses, addExpensesSelector, EmploymentExpensesController.show(taxYearEOY).url)
           buttonCheck(returnToOverview)
         }
@@ -319,8 +318,6 @@ class EmploymentSummaryViewSpec extends ViewUnitTest {
           linkCheck(s"$view$view $name", viewEmployerSelector(1), EmployerInformationController.show(taxYear, employmentId).url)
           textOnPageCheck(employerName2 + " " + startedDateBeforeString(taxYear - 1), employerNameSelector(id = 2))
           linkCheck(s"$view$view $employerName2", viewEmployerSelector(2), EmployerInformationController.show(taxYear, employmentId2).url)
-          textOnPageCheck(expenses, expensesHeadingSelector, "as a heading")
-          textOnPageCheck(specific.cannotAdd, cannotAddSelector)
           buttonCheck(returnToOverview)
         }
       }
@@ -338,11 +335,25 @@ class EmploymentSummaryViewSpec extends ViewUnitTest {
         h1Check(expectedH1)
         textOnPageCheck(specific.cannotUpdateInfo, cannotUpdateInfoSelector)
         captionCheck(expectedCaption(taxYear))
-        textOnPageCheck(employers, employersSelector)
         textOnPageCheck(thisIsATotal, thisIsATotalSelector)
-        textOnPageCheck(noEmployers, noEmployersSelector)
         textOnPageCheck(expenses, expensesHeadingSelector, "as a heading")
         textOnPageCheck(expenses, expensesLineSelector(true), "as a line item")
+        buttonCheck(returnToOverview)
+      }
+
+      "show the summary page when no data is in session and in year" which {
+        implicit val authRequest: AuthorisationRequest[AnyContent] = getAuthRequest(userScenario.isAgent)
+        implicit val messages: Messages = getMessages(userScenario.isWelsh)
+
+        val htmlFormat = underTest(taxYear, Seq.empty, expensesExist = false, isInYear = true, isAgent = userScenario.isAgent)
+
+        implicit val document: Document = Jsoup.parse(htmlFormat.body)
+
+        welshToggleCheck(userScenario.isWelsh)
+        titleCheck(expectedTitle, userScenario.isWelsh)
+        h1Check(expectedH1)
+        captionCheck(expectedCaption(taxYear))
+        textOnPageCheck(specific.cannotUpdateInfo, cannotUpdateInfoSelector)
         buttonCheck(returnToOverview)
       }
 
@@ -355,10 +366,11 @@ class EmploymentSummaryViewSpec extends ViewUnitTest {
         implicit val document: Document = Jsoup.parse(htmlFormat.body)
 
         welshToggleCheck(userScenario.isWelsh)
-        textOnPageCheck(expenses, expensesHeadingSelector, "as a heading")
-        linkCheck(addExpenses, addExpensesSelector, EmploymentExpensesController.show(taxYearEOY).url)
-        textOnPageCheck(employers, employersSelector, "as a heading")
-        linkCheck(addEmployer, addEmployerSelector(), EmploymentSummaryController.addNewEmployment(taxYearEOY).url)
+        titleCheck(expectedTitle, userScenario.isWelsh)
+        h1Check(expectedH1)
+        captionCheck(expectedCaption(taxYearEOY))
+        linkCheck(addEmployer, addEmployerSelector, EmploymentSummaryController.addNewEmployment(taxYearEOY).url, isExactUrlMatch = false)
+        buttonCheck(returnToOverview)
       }
     }
   }


### PR DESCRIPTION
### Description
Hide employer and expenses sections if there is no employment data defined.

[SASS-3048](https://jira.tools.tax.service.gov.uk/browse/SASS-3048)

### Checklist PR Reviewer
##### Before Reviewing
- [x]  Have you pulled the branch down?
- [x]  Have you assigned yourself to the PR?
- [x]  Have you moved the task to “in review” on JIRA?
- [x]  Have you checked to ensure all dependencies are up to date?
- [x]  Have you checked to ensure its been rebased against the current version of main?

##### Whilst Reviewing
- [x]  Have you run the tests?
- [x]  Have you run the journey tests?
- [x]  Have you looked at the JIRA story to make sure all Acceptance Criteria has been met?

##### After Reviewing
- [x]  Have you checked for merge conflicts or any changes in the current main that may affect the current pull request? i.e. does it need another rebase?
- [ ]  Have you checked to make sure there are no builds in the pipeline before you merge?
- [ ]  Have you moved the task to “in pipeline” on Jira?

### Checklist PR Raiser
##### Before creating PR
- [X]  Have you run the tests?
- [x]  Have you run the journey tests? (where applicable)
- [ ]  Have you addressed warnings where appropriate?
- [X]  Have you rebased against the current version of main?
- [X]  Have you checked code coverage isn’t lower than previously?

##### After PRs been raised
- [x]  Have you checked the PR Builder passes?
